### PR TITLE
support for writing X509 requests in DER format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ examples/Server
 
 .cabal-sandbox
 cabal.sandbox.config
+.stack-work/

--- a/HsOpenSSL.cabal
+++ b/HsOpenSSL.cabal
@@ -54,7 +54,7 @@ Library
         bytestring >= 0.9   && < 0.11,
         network    >= 2.1   && < 2.7,
         old-locale >= 1.0   && < 1.1,
-        time       >= 1.1.1 && < 1.6
+        time       >= 1.1.1 && < 1.9
         -- old-locale is only needed if time < 1.5, but Cabal does not
         -- allow us to express conditional dependencies like this.
 

--- a/OpenSSL/X509.hs
+++ b/OpenSSL/X509.hs
@@ -70,6 +70,7 @@ import OpenSSL.EVP.Internal
 import OpenSSL.Utils
 import OpenSSL.Stack
 import OpenSSL.X509.Name
+import Data.ByteString.Lazy (ByteString)
 
 -- |@'X509'@ is an opaque object that represents X.509 certificate.
 newtype X509  = X509 (ForeignPtr X509_)
@@ -200,11 +201,11 @@ writeX509' bio x509
            >>  return ()
 
 -- |@'writeDerX509' cert@ writes an X.509 certificate to DER string.
-writeDerX509 :: X509 -> IO String
+writeDerX509 :: X509 -> IO ByteString
 writeDerX509 x509
     = do mem <- newMem
          writeX509' mem x509
-         bioRead mem
+         bioReadLBS mem
 
 readX509' :: BIO -> IO X509
 readX509' bio
@@ -214,9 +215,9 @@ readX509' bio
            >>= wrapX509 
 
 -- |@'readDerX509' der@ reads in a certificate.
-readDerX509 :: String -> IO X509
+readDerX509 :: ByteString -> IO X509
 readDerX509 derStr
-    = newConstMem derStr >>= readX509'
+    = newConstMemLBS derStr >>= readX509'
 
 -- |@'compareX509' cert1 cert2@ compares two certificates.
 compareX509 :: X509 -> X509 -> IO Ordering

--- a/OpenSSL/X509/Request.hs
+++ b/OpenSSL/X509/Request.hs
@@ -29,6 +29,8 @@ module OpenSSL.X509.Request
 
     , getPublicKey
     , setPublicKey
+
+    , addExtensions
     )
     where
 
@@ -46,12 +48,14 @@ import           OpenSSL.X509 (X509)
 import qualified OpenSSL.X509 as Cert
 import           OpenSSL.X509.Name
 import           Data.ByteString.Lazy (ByteString)
+import           OpenSSL.Stack
 
 -- |@'X509Req'@ is an opaque object that represents PKCS#10
 -- certificate request.
 newtype X509Req  = X509Req (ForeignPtr X509_REQ)
 data    X509_REQ
 
+data    X509_EXT
 
 foreign import ccall unsafe "X509_REQ_new"
         _new :: IO (Ptr X509_REQ)
@@ -88,6 +92,13 @@ foreign import ccall unsafe "X509_REQ_get_pubkey"
 
 foreign import ccall unsafe "X509_REQ_set_pubkey"
         _set_pubkey :: Ptr X509_REQ -> Ptr EVP_PKEY -> IO CInt
+
+foreign import ccall unsafe "X509V3_EXT_nconf_nid"
+        _ext_create :: Ptr a -> Ptr b -> CInt -> CString -> IO (Ptr X509_EXT)
+
+foreign import ccall unsafe "X509_REQ_add_extensions"
+        _req_add_extensions :: Ptr X509_REQ -> Ptr STACK -> IO CInt
+
 
 -- |@'newX509Req'@ creates an empty certificate request. You must set
 -- the following properties to and sign it (see 'signX509Req') to
@@ -227,6 +238,21 @@ setPublicKey req pkey
       _set_pubkey reqPtr pkeyPtr
            >>= failIf (/= 1)
            >>  return ()
+
+
+-- |@'addExtensions' req [(nid, str)]@
+--
+-- E.g., nid 85 = 'subjectAltName' http://osxr.org:8080/openssl/source/crypto/objects/objects.h#0476
+--
+-- (TODO: more docs; NID type)
+addExtensions :: X509Req -> [(Int, String)] -> IO CInt
+addExtensions req exts =
+  withX509ReqPtr req $ \reqPtr -> do
+    extPtrs <- forM exts make
+    withStack extPtrs $ _req_add_extensions reqPtr
+
+  where
+    make (nid, str) = withCString str $ _ext_create nullPtr nullPtr (fromIntegral nid)
 
 
 -- |@'makeX509FromReq' req cert@ creates an empty X.509 certificate

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,34 +1,8 @@
-# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+resolver: lts-8.3
 
-# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-4.2
-
-# Local packages, usually specified by relative directory name
 packages:
 - '.'
 
-# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: []
-
-# Override default flag values for local packages and extra-deps
 flags:
   HsOpenSSL:
     fast-bignum: false
-
-# Extra package databases containing global packages
-extra-package-dbs: []
-
-# Control whether we use the GHC we find on the path
-# system-ghc: true
-
-# Require a specific version of stack, using version ranges
-# require-stack-version: -any # Default
-# require-stack-version: >= 1.0.0
-
-# Override the architecture used by stack, especially useful on Windows
-# arch: i386
-# arch: x86_64
-
-# Extra directories used by stack for building
-# extra-include-dirs: [/path/to/dir]
-# extra-lib-dirs: [/path/to/dir]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,34 @@
+# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-4.2
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags:
+  HsOpenSSL:
+    fast-bignum: false
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 1.0.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]


### PR DESCRIPTION
I guess you don't need this patch for your own project, but it probably belongs in your pull request to the upstream.

Actually, it occurred to me when I was looking at the OpenSSL.PEM module that the DER functions logically belong in (a new module named) OpenSSL.DER.  Perhaps you would be willing to put them all there?
